### PR TITLE
Fix for not hiding text input layouts for login/create account screen

### DIFF
--- a/app/src/androidTest/java/com/github/vase4kin/teamcityapp/account/create/view/CreateAccountActivityValidationTest.java
+++ b/app/src/androidTest/java/com/github/vase4kin/teamcityapp/account/create/view/CreateAccountActivityValidationTest.java
@@ -49,6 +49,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withContentDesc
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static com.github.vase4kin.teamcityapp.dagger.modules.Mocks.URL;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.when;
 
 /**
@@ -161,5 +162,21 @@ public class CreateAccountActivityValidationTest {
         onView(withId(R.id.user_name)).perform(typeText("user"), closeSoftKeyboard());
         onView(withId(R.id.action_create)).perform(click());
         onView(withText(R.string.server_password_cannot_be_empty)).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void testUserWillNotSeeUserAndPasswordFieldsWhenGuestAccountIsOn() throws Exception {
+        onView(withId(R.id.user_name)).perform(typeText("user"), pressImeActionButton());
+        onView(withId(R.id.password)).perform(typeText("pass"), closeSoftKeyboard());
+        // Enabling guest mode
+        onView(withId(R.id.guest_user_switch)).perform(click());
+        // Check input text layouts are not visible
+        onView(withId(R.id.user_field_wrapper)).check(matches(not(isDisplayed())));
+        onView(withId(R.id.password_field_wrapper)).check(matches(not(isDisplayed())));
+        // Enabling user mode
+        onView(withId(R.id.guest_user_switch)).perform(click());
+        // Check input text layouts are visible
+        onView(withId(R.id.user_field_wrapper)).check(matches(isDisplayed()));
+        onView(withId(R.id.password_field_wrapper)).check(matches(isDisplayed()));
     }
 }

--- a/app/src/androidTest/java/com/github/vase4kin/teamcityapp/login/view/LoginActivityValidationTest.java
+++ b/app/src/androidTest/java/com/github/vase4kin/teamcityapp/login/view/LoginActivityValidationTest.java
@@ -43,6 +43,7 @@ import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Validation tests for {@link LoginActivity}
@@ -109,4 +110,19 @@ public class LoginActivityValidationTest {
         onView(withText(R.string.server_password_cannot_be_empty)).check(matches(isDisplayed()));
     }
 
+    @Test
+    public void testUserWillNotSeeUserAndPasswordFieldsWhenGuestAccountIsOn() throws Exception {
+        onView(withId(R.id.user_name)).perform(typeText("user"), pressImeActionButton());
+        onView(withId(R.id.password)).perform(typeText("pass"), closeSoftKeyboard());
+        // Enabling guest mode
+        onView(withId(R.id.guest_user_switch)).perform(click());
+        // Check input text layouts are not visible
+        onView(withId(R.id.user_field_wrapper)).check(matches(not(isDisplayed())));
+        onView(withId(R.id.password_field_wrapper)).check(matches(not(isDisplayed())));
+        // Enabling user mode
+        onView(withId(R.id.guest_user_switch)).perform(click());
+        // Check input text layouts are visible
+        onView(withId(R.id.user_field_wrapper)).check(matches(isDisplayed()));
+        onView(withId(R.id.password_field_wrapper)).check(matches(isDisplayed()));
+    }
 }

--- a/app/src/main/java/com/github/vase4kin/teamcityapp/account/create/view/CreateAccountViewImpl.java
+++ b/app/src/main/java/com/github/vase4kin/teamcityapp/account/create/view/CreateAccountViewImpl.java
@@ -114,7 +114,9 @@ public class CreateAccountViewImpl implements CreateAccountView {
             @Override
             public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
                 mUserName.setVisibility(b ? View.GONE : View.VISIBLE);
+                mUserNameInputLayout.setVisibility(b ? View.GONE : View.VISIBLE);
                 mPassword.setVisibility(b ? View.GONE : View.VISIBLE);
+                mPasswordInputLayout.setVisibility(b ? View.GONE : View.VISIBLE);
                 setupViewsRegardingUserType(b, listener);
             }
         });

--- a/app/src/main/java/com/github/vase4kin/teamcityapp/login/view/LoginViewImpl.java
+++ b/app/src/main/java/com/github/vase4kin/teamcityapp/login/view/LoginViewImpl.java
@@ -81,8 +81,14 @@ public class LoginViewImpl implements LoginView {
     @BindView(R.id.teamcity_url_wrapper)
     TextInputLayout mServerUrlWrapperLayout;
 
+    @BindView(R.id.user_field_wrapper)
+    TextInputLayout mUserNameWrapperLayout;
+
     @BindView(R.id.user_name)
     EditText mUserName;
+
+    @BindView(R.id.password_field_wrapper)
+    TextInputLayout mPasswordWrapperLayout;
 
     @BindView(R.id.password)
     EditText mPassword;
@@ -138,7 +144,9 @@ public class LoginViewImpl implements LoginView {
             @Override
             public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
                 mUserName.setVisibility(b ? View.GONE : View.VISIBLE);
+                mUserNameWrapperLayout.setVisibility(b ? View.GONE : View.VISIBLE);
                 mPassword.setVisibility(b ? View.GONE : View.VISIBLE);
+                mPasswordWrapperLayout.setVisibility(b ? View.GONE : View.VISIBLE);
                 setupViewsRegardingUserType(b, listener);
                 hideKeyboard();
             }


### PR DESCRIPTION
## Scenario:
**GIVEN**: Navigate to login/create account screen
**WHEN**: Fill username and password fields
**AND**: Enable guest user mode
**THEN**: Text input layouts of user and pass textviews should be not visible 