### PR TITLE
Hide is pinned switcher divider as well

### DIFF
--- a/app/src/androidTest/java/com/github/vase4kin/teamcityapp/filter_builds/view/FilterBuildsActivityTest.java
+++ b/app/src/androidTest/java/com/github/vase4kin/teamcityapp/filter_builds/view/FilterBuildsActivityTest.java
@@ -218,6 +218,7 @@ public class FilterBuildsActivityTest {
 
         // Check switchers
         onView(withId(R.id.switcher_is_pinned)).check(matches(not(isDisplayed())));
+        onView(withId(R.id.divider_switcher_is_pinned)).check(matches(not(isDisplayed())));
         onView(withId(R.id.switcher_is_personal)).check(matches(isDisplayed()));
     }
 

--- a/app/src/main/java/com/github/vase4kin/teamcityapp/filter_builds/view/FilterBuildsViewImpl.java
+++ b/app/src/main/java/com/github/vase4kin/teamcityapp/filter_builds/view/FilterBuildsViewImpl.java
@@ -52,6 +52,9 @@ public class FilterBuildsViewImpl implements FilterBuildsView {
     @BindView(R.id.switcher_is_pinned)
     Switch mPinnedSwitch;
 
+    @BindView(R.id.divider_switcher_is_pinned)
+    View mPinnedSwitcherDivider;
+
     @OnClick(R.id.chooser_filter)
     public void onFilterChooserClick() {
         mFilterChooser.show();
@@ -127,6 +130,7 @@ public class FilterBuildsViewImpl implements FilterBuildsView {
     @Override
     public void hideSwitchForPinnedFilter() {
         mPinnedSwitch.setVisibility(View.GONE);
+        mPinnedSwitcherDivider.setVisibility(View.GONE);
     }
 
     /**
@@ -135,5 +139,6 @@ public class FilterBuildsViewImpl implements FilterBuildsView {
     @Override
     public void showSwitchForPinnedFilter() {
         mPinnedSwitch.setVisibility(View.VISIBLE);
+        mPinnedSwitcherDivider.setVisibility(View.VISIBLE);
     }
 }

--- a/app/src/main/res/layout/activity_filter_builds.xml
+++ b/app/src/main/res/layout/activity_filter_builds.xml
@@ -110,7 +110,9 @@
                     android:layout_height="match_parent"
                     android:text="@string/text_switcher_for_pinned" />
 
-                <include layout="@layout/layout_divider" />
+                <include
+                    layout="@layout/layout_divider"
+                    android:id="@+id/divider_switcher_is_pinned" />
 
             </LinearLayout>
 


### PR DESCRIPTION
## Scenario:
**GIVEN**: Navigate to filter builds screen
**WHEN**: Choose queued filter 
**THEN**: Is pinned switcher and its divider are not visible 