### PR TITLE
Fix show try it out crash

### DIFF
--- a/app/src/main/java/com/github/vase4kin/teamcityapp/login/view/LoginViewImpl.kt
+++ b/app/src/main/java/com/github/vase4kin/teamcityapp/login/view/LoginViewImpl.kt
@@ -371,14 +371,18 @@ class LoginViewImpl(private val activity: Activity) : LoginView {
      * {@inheritDoc}
      */
     override fun hideTryItOutLoading() {
-        progressBar.visibility = View.GONE
+        if (::progressBar.isInitialized) {
+            progressBar.visibility = View.GONE
+        }
     }
 
     /**
      * {@inheritDoc}
      */
     override fun showTryItOut() {
-        tryItOutTextView.visibility = View.VISIBLE
+        if (::tryItOutTextView.isInitialized) {
+            tryItOutTextView.visibility = View.VISIBLE
+        }
     }
 
     /**


### PR DESCRIPTION
```
FATAL EXCEPTION: main
Process: com.github.vase4kin.teamcityapp, PID: 28829
kotlin.UninitializedPropertyAccessException: lateinit property progressBar has not been initialized
	at com.github.vase4kin.teamcityapp.login.view.LoginViewImpl.hideTryItOutLoading(LoginViewImpl.java:374)
	at com.github.vase4kin.teamcityapp.login.presenter.LoginPresenterImpl$showTryItOut$2.invoke(LoginPresenterImpl.java:57)
	at com.github.vase4kin.teamcityapp.login.presenter.LoginPresenterImpl$showTryItOut$2.invoke(LoginPresenterImpl.java:34)
	at com.github.vase4kin.teamcityapp.remote.RemoteServiceImpl$showTryItOut$1.invoke(RemoteServiceImpl.java:44)
	at com.github.vase4kin.teamcityapp.remote.RemoteServiceImpl$showTryItOut$1.invoke(RemoteServiceImpl.java:25)
	at com.github.vase4kin.teamcityapp.remote.RemoteServiceImpl$getData$1.onComplete(RemoteServiceImpl.java:58)
	at com.google.android.gms.tasks.zzj.run(zzj.java:4)
	at android.os.Handler.handleCallback(Handler.java:739)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:148)
	at android.app.ActivityThread.main(ActivityThread.java:5585)
	at java.lang.reflect.Method.invoke(Method.java)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:730)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:620)
```