### PR TITLE
Update default firebase testing device to flame api 29

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
     parameters:
       devicemodel:
         description: "Device name to execute tests on"
-        default: "sailfish,version=28,locale=en,orientation=portrait"
+        default: "flame,version=29,locale=en,orientation=portrait"
         type: string
     steps:
       - *attach_workspace


### PR DESCRIPTION
Please add the details below:
